### PR TITLE
Introduce cone primitive

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -19,7 +19,7 @@
         "ianmackenzie/elm-1d-parameter": "1.0.1 <= v < 2.0.0",
         "ianmackenzie/elm-3d-camera": "3.0.0 <= v < 4.0.0",
         "ianmackenzie/elm-float-extra": "1.1.0 <= v < 2.0.0",
-        "ianmackenzie/elm-geometry": "3.4.0 <= v < 4.0.0",
+        "ianmackenzie/elm-geometry": "3.5.0 <= v < 4.0.0",
         "ianmackenzie/elm-geometry-linear-algebra-interop": "2.0.2 <= v < 3.0.0",
         "ianmackenzie/elm-triangular-mesh": "1.0.2 <= v < 2.0.0",
         "ianmackenzie/elm-units": "2.2.0 <= v < 3.0.0",

--- a/examples/Demo.elm
+++ b/examples/Demo.elm
@@ -8,6 +8,7 @@ import Browser.Dom
 import Browser.Events
 import Camera3d exposing (Camera3d)
 import Color
+import Cone3d
 import Cylinder3d
 import Direction3d exposing (Direction3d)
 import Frame3d exposing (Frame3d)
@@ -171,7 +172,7 @@ initialModel =
         [ { material = Nonmetal
           , roughness = 0.4
           , color = "#FF5555"
-          , kind = Cylinder
+          , kind = Cone
           , position = Frame3d.atPoint (Point3d.centimeters -15 -3 71.6)
           }
         , { material = Matte
@@ -217,7 +218,7 @@ type alias Object =
 
 type ObjectKind
     = Sphere
-    | Cylinder
+    | Cone
     | Cube
 
 
@@ -503,8 +504,8 @@ objectPanel index obj =
             Cube ->
                 "Cube"
 
-            Cylinder ->
-                "Cylinder"
+            Cone ->
+                "Cone"
         )
         [ materials (OnObjectMaterialChanged index) obj.material
         , colorPicker (OnObjectColorChanged index) "Color" obj.color
@@ -957,8 +958,8 @@ object { kind, position, material, color, roughness } =
         Cube ->
             Scene3d.placeIn position (cube objectMaterial)
 
-        Cylinder ->
-            Scene3d.placeIn position (cylinder objectMaterial)
+        Cone ->
+            Scene3d.placeIn position (cone objectMaterial)
 
 
 cube : Material.Uniform EntityCoordinates -> Scene3d.Entity EntityCoordinates
@@ -973,12 +974,12 @@ sphere material =
         |> Scene3d.sphere (Scene3d.castsShadows True) material
 
 
-cylinder : Material.Uniform EntityCoordinates -> Scene3d.Entity EntityCoordinates
-cylinder material =
-    Cylinder3d.startingAt
+cone : Material.Uniform EntityCoordinates -> Scene3d.Entity EntityCoordinates
+cone material =
+    Cone3d.startingAt
         Point3d.origin
         Direction3d.z
-        { radius = Length.centimeters 8, length = Length.centimeters 20 }
+        { radius = Length.centimeters 8, length = Length.centimeters 25 }
         |> Scene3d.cone (Scene3d.castsShadows True) material
 
 

--- a/examples/Demo.elm
+++ b/examples/Demo.elm
@@ -979,7 +979,7 @@ cylinder material =
         Point3d.origin
         Direction3d.z
         { radius = Length.centimeters 8, length = Length.centimeters 20 }
-        |> Scene3d.cylinder (Scene3d.castsShadows True) material
+        |> Scene3d.cone (Scene3d.castsShadows True) material
 
 
 bulb : DirectLight -> Maybe (Scene3d.Entity SceneCoordinates)

--- a/examples/elm.json
+++ b/examples/elm.json
@@ -18,7 +18,7 @@
             "ianmackenzie/elm-1d-parameter": "1.0.1",
             "ianmackenzie/elm-3d-camera": "3.0.0",
             "ianmackenzie/elm-float-extra": "1.1.0",
-            "ianmackenzie/elm-geometry": "3.4.0",
+            "ianmackenzie/elm-geometry": "3.5.0",
             "ianmackenzie/elm-geometry-linear-algebra-interop": "2.0.1",
             "ianmackenzie/elm-interval": "2.0.0",
             "ianmackenzie/elm-triangular-mesh": "1.0.2",

--- a/src/Scene3d.elm
+++ b/src/Scene3d.elm
@@ -276,7 +276,7 @@ cylinder (CastsShadows shadowFlag) givenMaterial givenCylinder =
     Entity.cylinder shadowFlag givenMaterial givenCylinder
 
 
-{-| Draw a cone using the [`Cylinder3d`](https://package.elm-lang.org/packages/ianmackenzie/elm-geometry/latest/Cone3d)
+{-| Draw a cone using the [`Cone3d`](https://package.elm-lang.org/packages/ianmackenzie/elm-geometry/latest/Cone3d)
 type from `elm-geometry`.
 -}
 cone : CastsShadows Bool -> Material.Uniform coordinates -> Cone3d Meters coordinates -> Entity coordinates

--- a/src/Scene3d.elm
+++ b/src/Scene3d.elm
@@ -157,6 +157,7 @@ import BoundingBox3d exposing (BoundingBox3d)
 import Camera3d exposing (Camera3d)
 import Color exposing (Color)
 import Color.Transparent
+import Cone3d exposing (Cone3d)
 import Cylinder3d exposing (Cylinder3d)
 import Direction3d exposing (Direction3d)
 import Duration exposing (Duration)
@@ -278,7 +279,7 @@ cylinder (CastsShadows shadowFlag) givenMaterial givenCylinder =
 {-| Draw a cone using the [`Cylinder3d`](https://package.elm-lang.org/packages/ianmackenzie/elm-geometry/latest/Cone3d)
 type from `elm-geometry`.
 -}
-cone : CastsShadows Bool -> Material.Uniform coordinates -> Cylinder3d Meters coordinates -> Entity coordinates
+cone : CastsShadows Bool -> Material.Uniform coordinates -> Cone3d Meters coordinates -> Entity coordinates
 cone (CastsShadows shadowFlag) givenMaterial givenCone =
     Entity.cone shadowFlag givenMaterial givenCone
 

--- a/src/Scene3d.elm
+++ b/src/Scene3d.elm
@@ -1,7 +1,7 @@
 module Scene3d exposing
     ( toHtml, unlit, sunny, cloudy, office
     , Entity
-    , quad, block, sphere, cylinder
+    , quad, block, sphere, cylinder, cone
     , mesh
     , group, nothing
     , shadow, withShadow
@@ -51,7 +51,7 @@ specify a material to use. However, different shapes support different kinds of
 materials; `quad`s and `sphere`s support all materials, while `block`s and
 `cylinder`s only support uniform (non-textured) materials.
 
-@docs quad, block, sphere, cylinder
+@docs quad, block, sphere, cylinder, cone
 
 
 ## Meshes
@@ -273,6 +273,14 @@ type from `elm-geometry`.
 cylinder : CastsShadows Bool -> Material.Uniform coordinates -> Cylinder3d Meters coordinates -> Entity coordinates
 cylinder (CastsShadows shadowFlag) givenMaterial givenCylinder =
     Entity.cylinder shadowFlag givenMaterial givenCylinder
+
+
+{-| Draw a cone using the [`Cylinder3d`](https://package.elm-lang.org/packages/ianmackenzie/elm-geometry/latest/Cone3d)
+type from `elm-geometry`.
+-}
+cone : CastsShadows Bool -> Material.Uniform coordinates -> Cylinder3d Meters coordinates -> Entity coordinates
+cone (CastsShadows shadowFlag) givenMaterial givenCone =
+    Entity.cone shadowFlag givenMaterial givenCone
 
 
 {-| Draw the given mesh (shape) with the given material. Check out the [`Mesh`](Scene3d-Mesh)

--- a/src/Scene3d/Entity.elm
+++ b/src/Scene3d/Entity.elm
@@ -24,6 +24,7 @@ import Axis3d exposing (Axis3d)
 import Block3d exposing (Block3d)
 import BoundingBox3d exposing (BoundingBox3d)
 import Color exposing (Color)
+import Cone3d exposing (Cone3d)
 import Cylinder3d exposing (Cylinder3d)
 import Direction3d exposing (Direction3d)
 import Float.Extra as Float
@@ -974,17 +975,17 @@ cylinder castsShadow givenMaterial givenCylinder =
         |> placeIn centerFrame
 
 
-cone : Bool -> Material.Uniform coordinates -> Cylinder3d Meters coordinates -> Entity coordinates
+cone : Bool -> Material.Uniform coordinates -> Cone3d Meters coordinates -> Entity coordinates
 cone castsShadow givenMaterial givenCone =
     let
         (Quantity radius) =
-            Cylinder3d.radius givenCone
+            Cone3d.radius givenCone
 
         (Quantity length) =
-            Cylinder3d.length givenCone
+            Cone3d.length givenCone
 
-        centerFrame =
-            Frame3d.fromZAxis (Cylinder3d.axis givenCone)
+        baseFrame =
+            Frame3d.fromZAxis (Cone3d.axis givenCone)
 
         baseEntity =
             mesh givenMaterial Primitives.cone
@@ -998,7 +999,7 @@ cone castsShadow givenMaterial givenCone =
     in
     untransformedEntity
         |> transformBy (Transformation.preScale radius radius length)
-        |> placeIn centerFrame
+        |> placeIn baseFrame
 
 
 shadow : Shadow coordinates -> Entity coordinates

--- a/src/Scene3d/Entity.elm
+++ b/src/Scene3d/Entity.elm
@@ -1,6 +1,7 @@
 module Scene3d.Entity exposing
     ( Entity
     , block
+    , cone
     , cylinder
     , empty
     , group
@@ -964,6 +965,33 @@ cylinder castsShadow givenMaterial givenCylinder =
         untransformedEntity =
             if castsShadow then
                 group [ baseEntity, shadow Primitives.cylinderShadow ]
+
+            else
+                baseEntity
+    in
+    untransformedEntity
+        |> transformBy (Transformation.preScale radius radius length)
+        |> placeIn centerFrame
+
+
+cone : Bool -> Material.Uniform coordinates -> Cylinder3d Meters coordinates -> Entity coordinates
+cone castsShadow givenMaterial givenCone =
+    let
+        (Quantity radius) =
+            Cylinder3d.radius givenCone
+
+        (Quantity length) =
+            Cylinder3d.length givenCone
+
+        centerFrame =
+            Frame3d.fromZAxis (Cylinder3d.axis givenCone)
+
+        baseEntity =
+            mesh givenMaterial Primitives.cone
+
+        untransformedEntity =
+            if castsShadow then
+                group [ baseEntity, shadow Primitives.coneShadow ]
 
             else
                 baseEntity

--- a/src/Scene3d/Primitives.elm
+++ b/src/Scene3d/Primitives.elm
@@ -249,9 +249,6 @@ cone =
         negativeZVector =
             Direction3d.negativeZ |> Direction3d.toVector
 
-        positiveZVector =
-            Direction3d.positiveZ |> Direction3d.toVector
-
         bottomZ =
             Quantity.zero
 


### PR DESCRIPTION
This is work in progress, for now I'm rendering Cylinder3d as a cone because it is difficult to integrate with local elm-geometry. 

The Cone3d type is introduced in [this pr](https://github.com/ianmackenzie/elm-geometry/pull/131).

After changing `Demo.elm` to render the cone, I got a weird shadow on the cone, that looks different for the cylinder.

<img width="488" alt="Screenshot 2020-05-01 at 17 39 25" src="https://user-images.githubusercontent.com/43472/80819459-5050f800-8bd5-11ea-8bd4-8550767f7364.png">

<img width="583" alt="Screenshot 2020-05-01 at 17 46 10" src="https://user-images.githubusercontent.com/43472/80819466-53e47f00-8bd5-11ea-8857-0b964ef76b2b.png">
